### PR TITLE
Header include fixes

### DIFF
--- a/btrack/BTrack.cpp
+++ b/btrack/BTrack.cpp
@@ -19,7 +19,7 @@
  */
 //=======================================================================
 
-#include <cmath>
+#include <math.h>
 #include <algorithm>
 #include "BTrack.h"
 #include <iostream>

--- a/src/abcreader.cpp
+++ b/src/abcreader.cpp
@@ -17,6 +17,7 @@
 #include "abcreader.h"
 #include "audioengine.h"
 #include <iostream>
+#include <math.h>
 
 using namespace bipscript;
 using namespace midi;

--- a/src/oscmessage.h
+++ b/src/oscmessage.h
@@ -21,6 +21,7 @@
 #include "scripttypes.h"
 
 #include <string>
+#include <vector>
 #include <cstring>
 
 namespace bipscript {


### PR DESCRIPTION
I had some trouble compiling Bipscript on a recent Debian system. These changes let me compile and are also a bit more "correct."